### PR TITLE
fix: improve proxy server configuration and health checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 *.log
+**/.env

--- a/wordthread/server/src/index.js
+++ b/wordthread/server/src/index.js
@@ -2,7 +2,17 @@ const express = require('express');
 const morgan = require('morgan');
 const cors = require('cors');
 const { createProxyMiddleware } = require('http-proxy-middleware');
-require('dotenv').config();
+const path = require('path');
+
+// Load environment variables from the project root regardless of the
+// current working directory. This avoids runtime failures when the
+// server is launched via npm workspaces which set a different cwd.
+require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
+
+if (!process.env.ME_BASE_URL) {
+  console.error('ME_BASE_URL is not defined. Please set it in server/.env');
+  process.exit(1);
+}
 
 const app = express();
 const port = process.env.PORT || 7071;
@@ -10,8 +20,13 @@ const port = process.env.PORT || 7071;
 app.use(morgan('dev'));
 app.use(cors());
 
+// Simple health check endpoint for monitoring
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
 // Proxy middleware
-const apiProxy = createProxyMiddleware('/api', {
+const apiProxy = createProxyMiddleware({
   target: process.env.ME_BASE_URL,
   changeOrigin: true,
   pathRewrite: { '^/api': '' },


### PR DESCRIPTION
## Summary
- load environment variables from server/.env regardless of cwd
- add `/health` endpoint for monitoring
- fix http-proxy-middleware usage for v3 API and ignore `.env` files

## Testing
- `node server/src/index.js &` *(fails: EADDRINUSE or network restrictions)*
- `curl -i localhost:7071/health`


------
https://chatgpt.com/codex/tasks/task_b_68b0c6f5ad708322900142d12904546d